### PR TITLE
https doc fix for wordpress url

### DIFF
--- a/README.org
+++ b/README.org
@@ -60,7 +60,7 @@
     #+BEGIN_SRC emacs-lisp
       (setq org2blog/wp-blog-alist
             '(("wordpress"
-               :url "http://username.wordpress.com/xmlrpc.php"
+               :url "https://username.wordpress.com/xmlrpc.php"
                :username "username"
                :default-title "Hello World"
                :default-categories ("org2blog" "emacs")


### PR DESCRIPTION
M-x org2blog/wp-login does not work anymore for wordpress,
you get an "xml-rpc-request: Error during request: 301" error.

Fix use:
url "https://username.wordpress.com/xmlrpc.php"
instead of
url "http://username.wordpress.com/xmlrpc.php"