### PR TITLE
Downcase language name

### DIFF
--- a/ox-wp.el
+++ b/ox-wp.el
@@ -55,7 +55,7 @@ contextual information."
     (if (not sc)
         (org-html-src-block src-block contents info)
       (format "[sourcecode language=\"%s\" title=\"%s\" %s]\n%s[/sourcecode]"
-              (or (cdr (assoc lang langs-map)) lang "text")
+              (or (cdr (assoc lang langs-map)) (downcase lang) "text")
               (or caption "")
               (or syntaxhl "")
               (org-export-format-code-default src-block info)))))


### PR DESCRIPTION
I am using R with SyntaxHighlighter Evolved.  It appears that it will not format the code if the language name is uppercase:

    [sourcecode language="R"]

vs.

    [sourcecode language="r"]

This trivial patch downcases the language name.  It appears to work in my up-to-date Wordpress install.

