### PR TITLE
Guard downcase from lang with nil value

### DIFF
--- a/ox-wp.el
+++ b/ox-wp.el
@@ -55,7 +55,7 @@ contextual information."
     (if (not sc)
         (org-html-src-block src-block contents info)
       (format "[sourcecode language=\"%s\" title=\"%s\" %s]\n%s[/sourcecode]"
-              (or (cdr (assoc lang langs-map)) (downcase lang) "text")
+              (or (cdr (assoc lang langs-map)) (when lang (downcase lang)) "text")
               (or caption "")
               (or syntaxhl "")
               (org-export-format-code-default src-block info)))))


### PR DESCRIPTION
It turns out that downcase errors if provided with nil argument.

Although I have not encountered a case where lang is nil, the presence of the third argument being "text" makes me think that the second argument could be nil and should hand this gracefully.