### PR TITLE
bugfix:  don't only publish selected region

### DIFF
--- a/org2blog.el
+++ b/org2blog.el
@@ -616,6 +616,7 @@ from currently logged in."
   (interactive "P")
   (org2blog/wp-mode t) ;; turn on org2blog-wp-mode
   (org2blog/wp-correctly-login)
+  (deactivate-mark)
   (save-excursion
     (save-restriction
       (let ((post (org2blog/wp--export-as-post subtree-p))


### PR DESCRIPTION
If the mark was set in a buffer, and a region selected, then calling `wp-post-buffer` causes only this region's text to be published, which is generally not desirable.  This is fixed by ensuring that no region is selected before exporting the buffer.